### PR TITLE
AMQP: Declare exchange passive and durable

### DIFF
--- a/contrib/tx.py
+++ b/contrib/tx.py
@@ -6,7 +6,7 @@ import sys
 connection = pika.BlockingConnection(pika.ConnectionParameters(host='kazhua.suse.de'))
 channel = connection.channel()
 
-channel.exchange_declare(exchange='pubsub', type='topic')
+channel.exchange_declare(exchange='pubsub', type='topic', passive=True, durable=True)
 
 routing_key = sys.argv[1] if len(sys.argv) > 1 else 'anonymous.info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'

--- a/suse_msg/consume.py
+++ b/suse_msg/consume.py
@@ -72,7 +72,7 @@ while True:
         connection = pika.BlockingConnection(pika.URLParameters(config['amqp']['server']))
         channel = connection.channel()
 
-        channel.exchange_declare(exchange=config['amqp']['exchange'], type='topic')
+        channel.exchange_declare(exchange=config['amqp']['exchange'], type='topic', passive=True, durable=True)
 
         result = channel.queue_declare(exclusive=True)
         queue_name = result.method.queue


### PR DESCRIPTION
This will allow the rabbitmq user to use less privileges.
The exchange needs to be created by the rabbitmq admin.

See also: https://w3.suse.de/~dheidler/amqp.html